### PR TITLE
Add production page and log component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # director-sim-game
 A web-based text simulation game where players build a career as a film, TV, or commercial director.
+
+## Development
+
+Pages and components are located in `src/`. The `Production` page displays live updates from the production process. It uses Tailwind CSS classes for styling.
+
+### Production Page
+- **src/pages/Production.jsx**: Fetches production data via POST `/start_production`, shows logs using `ProductionLog` and lets the player finish production which posts to `/release_project`.
+- **src/components/ProductionLog.jsx**: Renders production notes as a timeline-styled list.

--- a/src/components/ProductionLog.jsx
+++ b/src/components/ProductionLog.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * ProductionLog renders a list of production notes as a styled timeline.
+ * @param {{notes: string[]}} props
+ */
+const ProductionLog = ({ notes = [] }) => {
+  return (
+    <ul className="ml-4 border-l-2 border-gray-300 pl-4">
+      {notes.map((note, idx) => (
+        <li key={idx} className="mb-2">
+          <div className="relative pb-2">
+            <span className="absolute -left-2.5 w-2 h-2 bg-blue-500 rounded-full top-1"></span>
+            {note}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ProductionLog;

--- a/src/pages/Production.jsx
+++ b/src/pages/Production.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ProductionLog from '../components/ProductionLog';
+
+/**
+ * Production page displays live production events and outcomes.
+ */
+const Production = () => {
+  const navigate = useNavigate();
+  const [log, setLog] = useState([]);
+  const [delays, setDelays] = useState('');
+  const [issues, setIssues] = useState('');
+  const [feedback, setFeedback] = useState('');
+  const [qualityScore, setQualityScore] = useState(null);
+
+  useEffect(() => {
+    const fetchProduction = async () => {
+      try {
+        const res = await fetch('/start_production', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to start production');
+        const data = await res.json();
+        setLog(data.production_notes || []);
+        setDelays(data.delays);
+        setIssues(data.issues);
+        setFeedback(data.studio_feedback);
+        setQualityScore(data.final_quality_score);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchProduction();
+  }, []);
+
+  const handleFinishProduction = async () => {
+    try {
+      await fetch('/release_project', { method: 'POST' });
+    } catch (err) {
+      console.error(err);
+    }
+    navigate('/results');
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Production In Progress</h1>
+      {qualityScore !== null && (
+        <p className="text-lg">Final Quality Score: {qualityScore}</p>
+      )}
+      {delays && (
+        <div className="bg-yellow-100 text-yellow-800 p-4 rounded">
+          <strong>Delays:</strong> {delays}
+        </div>
+      )}
+      {issues && (
+        <div className="bg-red-100 text-red-800 p-4 rounded">
+          <strong>Major Issues:</strong> {issues}
+        </div>
+      )}
+      <ProductionLog notes={log} />
+      {feedback && (
+        <div className="bg-gray-100 text-gray-800 p-4 rounded mt-4">
+          <strong>Studio Feedback:</strong> {feedback}
+        </div>
+      )}
+      <button
+        className="mt-6 px-4 py-2 bg-blue-600 text-white rounded"
+        onClick={handleFinishProduction}
+      >
+        Finish Production
+      </button>
+    </div>
+  );
+};
+
+export default Production;


### PR DESCRIPTION
## Summary
- add `ProductionLog` component for timeline style list of notes
- add `Production` page that posts to `/start_production` and `/release_project`
- document new files in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842164c00448323985218afea470ddc