### PR TITLE
Add career profile page

### DIFF
--- a/src/components/ProfileEntry.jsx
+++ b/src/components/ProfileEntry.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+/**
+ * Display a single past project entry.
+ * Poster integration left for future builds.
+ */
+export default function ProfileEntry({ project }) {
+  return (
+    <div className="flex items-start space-x-4 py-4 border-b border-gray-200">
+      {/* Placeholder for poster image */}
+      <div className="w-16 h-24 bg-gray-100 flex-shrink-0" />
+      <div className="flex-1">
+        <div className="flex justify-between items-baseline">
+          <h3 className="text-lg font-semibold">{project.title}</h3>
+          {project.year && <span className="text-sm text-gray-500">{project.year}</span>}
+        </div>
+        <p className="text-sm text-gray-600">{project.medium} &bull; {project.genre}</p>
+        <p className="text-sm mt-1">Critics: {project.critics_score} | Fans: {project.fan_score}</p>
+        {project.awards && project.awards.length > 0 && (
+          <p className="text-sm text-yellow-600 mt-1">Awards: {project.awards.join(', ')}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import ProfileEntry from '../components/ProfileEntry';
+
+export default function Profile() {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      try {
+        const res = await fetch('/get_profile');
+        if (!res.ok) throw new Error('Failed to load profile');
+        const data = await res.json();
+        setProfile(data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchProfile();
+  }, []);
+
+  if (loading) return <p>Loading profile...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+  if (!profile) return null;
+
+  const {
+    total_projects,
+    average_critics_score,
+    average_fan_score,
+    career_box_office,
+    awards,
+    projects = [],
+  } = profile;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Career Profile</h1>
+      <div className="grid grid-cols-2 gap-4 mb-8 text-sm">
+        <div className="bg-gray-50 p-4 rounded">
+          <p className="text-gray-600">Total Projects</p>
+          <p className="text-xl font-semibold">{total_projects}</p>
+        </div>
+        <div className="bg-gray-50 p-4 rounded">
+          <p className="text-gray-600">Average Critics Score</p>
+          <p className="text-xl font-semibold">{average_critics_score}</p>
+        </div>
+        <div className="bg-gray-50 p-4 rounded">
+          <p className="text-gray-600">Average Fan Score</p>
+          <p className="text-xl font-semibold">{average_fan_score}</p>
+        </div>
+        <div className="bg-gray-50 p-4 rounded">
+          <p className="text-gray-600">Career Box Office</p>
+          <p className="text-xl font-semibold">${career_box_office.toLocaleString()}</p>
+        </div>
+        {awards && awards.length > 0 && (
+          <div className="col-span-2 bg-yellow-50 p-4 rounded">
+            <p className="text-yellow-700 font-medium">Awards Won</p>
+            <p>{awards.join(', ')}</p>
+          </div>
+        )}
+      </div>
+
+      <h2 className="text-xl font-semibold mb-4">Past Projects</h2>
+      <div>
+        {projects.map((project) => (
+          <ProfileEntry key={project.id} project={project} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ProfileEntry` for displaying project details
- add `Profile` page to fetch and display career statistics and project history

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68421837c0cc8323bc6ee4e213344cce