### PR TITLE
Fix cast payload format

### DIFF
--- a/src/pages/Project.jsx
+++ b/src/pages/Project.jsx
@@ -48,7 +48,7 @@ function Project() {
       await fetch('/select_cast', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ selections: selected }),
+        body: JSON.stringify({ cast_ids: Object.values(selected) }),
       });
       navigate('/production');
     } catch (err) {


### PR DESCRIPTION
## Summary
- send cast IDs array when confirming cast selection

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68434fc17660832398dfd5b785d18483