### PR TITLE
Enable player object serialization

### DIFF
--- a/backend/game_engine/player.py
+++ b/backend/game_engine/player.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Dict, List
 
 try:
@@ -43,3 +43,10 @@ class Player:
             "genre_strengths": self.genre_strengths,
             "projects_completed": len(self.past_projects),
         }
+
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-serializable representation of the player."""
+        data = asdict(self)
+        if hasattr(self, "completed_projects"):
+            data["completed_projects"] = getattr(self, "completed_projects")
+        return data


### PR DESCRIPTION
## Summary
- support JSON serialization of `Player`

## Testing
- `python3 -m py_compile backend/game_engine/player.py`
- `python3 - <<'EOF'
from backend.game_engine.player import Player
p = Player('Test', reputation=50)
print(p.to_dict())
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_68434fc6b2788323bdae9f9928da1d48