### PR TITLE
Fix project context destructuring

### DIFF
--- a/src/pages/Project.jsx
+++ b/src/pages/Project.jsx
@@ -5,7 +5,7 @@ import { useProject } from '../contexts/ProjectContext';
 
 function Project() {
   const navigate = useNavigate();
-  const { project } = useProject();
+  const { selectedProject: project } = useProject();
   const [talentPools, setTalentPools] = useState({});
   const [selected, setSelected] = useState({});
   const [error, setError] = useState('');


### PR DESCRIPTION
## Summary
- use `selectedProject` alias when loading project context

## Testing
- `grep -n "selectedProject" -R src | head`

------
https://chatgpt.com/codex/tasks/task_e_6843562f98248323a79b1599cb02e689