### PR TITLE
Update routing to include full page lineup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
-
-const ProjectPage = () => (
-  <div className="p-4">Project Page Placeholder</div>
-);
+import { Dashboard, Project, Production, Results, Profile } from './pages';
 
 const App = () => (
   <Routes>
     <Route path="/" element={<Dashboard />} />
-    <Route path="/project" element={<ProjectPage />} />
+    <Route path="/project" element={<Project />} />
+    <Route path="/production" element={<Production />} />
+    <Route path="/results" element={<Results />} />
+    <Route path="/profile" element={<Profile />} />
   </Routes>
 );
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,5 @@
+export { default as Dashboard } from './Dashboard';
+export { default as Project } from './Project';
+export { default as Production } from './Production';
+export { default as Results } from './Results';
+export { default as Profile } from './Profile';


### PR DESCRIPTION
## Summary
- create `src/pages/index.js` to re-export pages
- update `src/App.jsx` to import pages from the new barrel file
- expand `<Routes>` with paths for Project, Production, Results and Profile

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import "prop-types")*

------
https://chatgpt.com/codex/tasks/task_e_68435631e7048323b01eabd8981d0086