### PR TITLE
Initialize game on dashboard

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -9,4 +9,8 @@ export const getProjects = () => api.get('/get_projects');
 export const selectProject = (id) =>
   api.post('/select_project', { project_id: id });
 
+// Start a new game session with a default player name
+export const startGame = (name = 'Player') =>
+  api.post('/start_game', { name });
+
 export default api;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getProjects, selectProject } from '../api/api';
+import { getProjects, selectProject, startGame } from '../api/api';
 import ProjectCard from '../components/ProjectCard';
 import { useProject } from '../contexts/ProjectContext';
 
@@ -12,19 +12,24 @@ const Dashboard = () => {
   const { setSelectedProject } = useProject();
 
   useEffect(() => {
-    const fetchProjects = async () => {
+    let isMounted = true;
+    const startAndFetch = async () => {
       setLoading(true);
       try {
+        await startGame('Player');
         const { data } = await getProjects();
-        setProjects(data.offers);
+        if (isMounted) setProjects(data.offers);
       } catch (err) {
-        setError('Failed to load projects');
+        if (isMounted) setError('Failed to load projects');
       } finally {
-        setLoading(false);
+        if (isMounted) setLoading(false);
       }
     };
 
-    fetchProjects();
+    startAndFetch();
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const handleSelect = async (project) => {


### PR DESCRIPTION
## Summary
- add API helper to start the game session
- initialize the game when the dashboard loads before fetching projects

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68435aba859c8323ae336ad0606dfac5