### PR TITLE
Fix home navigation in results page

### DIFF
--- a/src/pages/Results.jsx
+++ b/src/pages/Results.jsx
@@ -78,7 +78,7 @@ function Results() {
         </p>
       </div>
       <button
-        onClick={() => navigate('/dashboard')}
+        onClick={() => navigate('/')}
         className="mt-6 bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded"
       >
         Return to Dashboard


### PR DESCRIPTION
## Summary
- use `navigate('/')` on the results page button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68435ac0f9f08323b94bbc7aa16b8dee