### PR TITLE
Add session cleanup for talent pools

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -137,6 +137,7 @@ def release_project():
     completed = dict(project)
     completed.update(release_results)
     add_completed_project(player, completed)
+    SESSION.pop("talent_pools", None)
 
     SESSION.pop("selected_project", None)
     SESSION.pop("selected_cast", None)


### PR DESCRIPTION
## Summary
- clear `talent_pools` when releasing a project

## Testing
- `python -m py_compile backend/app.py backend/game_engine/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68435ac60d188323966e55ce70569476