### PR TITLE
Check existing player session

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,12 @@ def start_game():
     if not name:
         return jsonify({"error": "Name is required"}), 400
 
+    # If a player already exists in the session, return it without creating
+    # a new one so repeated calls are idempotent.
+    existing = SESSION.get("player")
+    if existing:
+        return jsonify(asdict(existing))
+
     player = Player(name)
     SESSION["player"] = player
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -13,20 +13,31 @@ const Dashboard = () => {
 
   useEffect(() => {
     let isMounted = true;
-    const startAndFetch = async () => {
+    const fetchProjects = async () => {
       setLoading(true);
       try {
-        await startGame('Player');
+        // Attempt to fetch projects without starting a new game.
         const { data } = await getProjects();
         if (isMounted) setProjects(data.offers);
       } catch (err) {
-        if (isMounted) setError('Failed to load projects');
+        // If the game hasn't started yet, start a new session then retry.
+        if (err.response?.data?.error === 'Game not started') {
+          try {
+            await startGame('Player');
+            const { data } = await getProjects();
+            if (isMounted) setProjects(data.offers);
+          } catch (startErr) {
+            if (isMounted) setError('Failed to load projects');
+          }
+        } else if (isMounted) {
+          setError('Failed to load projects');
+        }
       } finally {
         if (isMounted) setLoading(false);
       }
     };
 
-    startAndFetch();
+    fetchProjects();
     return () => {
       isMounted = false;
     };


### PR DESCRIPTION
## Summary
- return existing player in `/start_game`
- lazily start new game in dashboard when necessary

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import "prop-types" from `src/components/CastCard.jsx`)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6843870e2a188323998f7cd88e0e9ca1