### PR TITLE
Fix award name casing

### DIFF
--- a/backend/game_engine/constants.py
+++ b/backend/game_engine/constants.py
@@ -51,13 +51,13 @@ ROLES = [
 
 # Awards used in the game
 AWARDS = [
-    'best picture',
-    'best director',
-    'best screenplay',
-    'best actor',
-    'best actress',
-    'audience choice',
-    'best visual effects'
+    'Best Picture',
+    'Best Director',
+    'Best Screenplay',
+    'Best Actor',
+    'Best Actress',
+    'Audience Choice',
+    'Best Visual Effects'
 ]
 
 # Default tone options


### PR DESCRIPTION
## Summary
- make awards use title case in constants to match release evaluation logic

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438717c2488323a3314a552cc36bb8